### PR TITLE
cleanup(): Multiple match resilience

### DIFF
--- a/source/usr/local/emhttp/plugins/un-get/un-get
+++ b/source/usr/local/emhttp/plugins/un-get/un-get
@@ -441,7 +441,7 @@ cleanup() {
   PACKAGE_LIST_INSTALLED="$(cat /boot/config/plugins/un-get/installedpackages_list)"
   for p in ${BOOT_PKGS}
   do
-    if [ ! $(grep ${p%.*} <<< "${INSTALLED_PKGS}") ]; then
+    if [ $(grep "${p%.*}" <<< "${INSTALLED_PKGS}" | wc -l) -eq 0 ]; then
       if [ -z "${CLEANUP_LIST}" ]; then
         CLEANUP_LIST="${p}"
       else
@@ -464,7 +464,7 @@ cleanup() {
     echo "Please wait, checking if package list is up-to-date...!"
     for p in ${PACKAGE_LIST_INSTALLED}
     do
-      if [ ! $(grep ${p%.*} <<< "${INSTALLED_PKGS}") ]; then
+      if [ $(grep "${p%.*}" <<< "${INSTALLED_PKGS}" | wc -l) -eq 0 ]; then
         sed -i "/$p/d" /boot/config/plugins/un-get/installedpackages_list
       fi
     done


### PR DESCRIPTION
In certain cases, there can be something like:

```console
$ un-get cleanup
/usr/bin/un-get: line 444: [: libmediainfo-24.06-x86_64-1ponce: unary operator expected
Nothing to clean up!
```

This is because, uncommonly but perhaps not uniquely, there can be a situation like:
```console
$ un-get installed
Currently installed package(s) by un-get:
mosh-1.4.0-x86_64-4.txz
mediainfo-24.06-x86_64-1ponce.txz
libzen-0.4.41-x86_64-1ponce.txz
graphviz-12.1.0-x86_64-2cf.txz
libmms-0.6.4-x86_64-3ponce.txz
libmediainfo-24.06-x86_64-1ponce.txz
tinyxml2-10.0.0-x86_64-1ponce.txz

$ grep mediainfo-24.06-x86_64-1ponce <<< "$(ls -1 /var/log/packages/)"
libmediainfo-24.06-x86_64-1ponce
mediainfo-24.06-x86_64-1ponce
```

Which throws off the cleanup() routine, as it does not expect two "arguments" in the form of files.

This change replaces the ! check with a grep and count instead.